### PR TITLE
fix: get one month of commits, in UTC timezone

### DIFF
--- a/monthly-blog.sh
+++ b/monthly-blog.sh
@@ -6,7 +6,7 @@ echo ""
 echo "Where YYYY is a 4-digit year, and M is the number of the month."
 echo "Example: monthly-blog.sh 2021 8 ~/mathlib"
 echo "It is important that M is a natural number between 1 and 12."
-echo "Do not write 08 to denote August. Write 8 instead."
+echo "The formats '02' and '2' are both allowed."
 echo ""
 echo "Important: make sure that the mathlib clone is clean,"
 echo "and points to an up-to-date copy of master."
@@ -19,9 +19,12 @@ year=$1
 month=$2
 mathlib=$3
 
-# 1-indexed arrays
-monthnames_uc=("NaM" "Jan" "Feb" "Mar" "Apr" "May" "Jun" "Jul" "Aug" "Sep" "Oct" "Nov" "Dec")
-monthnames_lc=("NaM" "jan" "feb" "mar" "apr" "may" "jun" "jul" "aug" "sep" "oct" "nov" "dec")
+# the number of days in the given month in the given year
+daysOfMonth="$(date -d "$year/$month/1 + 1 month - 1 day" "+%d")"
+# the 3-letter month first letter capitalized
+month_uc="$(date -d "$year/$month/1" "+%b")"
+# the 3-letter month lowercase
+month_lc="$(date -d "$year/$month/1" "+%b" | tr A-Z a-z)"
 
 echo "---"
 echo "author: 'Mathlib community'"
@@ -32,9 +35,9 @@ echo "date: $(date -u +'%Y-%m-%d %H:%M:%S+00:00')"
 echo "description: ''"
 echo "has_math: true"
 echo "link: ''"
-echo "slug: month-in-mathlib-${monthnames_lc[$month]}-$year"
+echo "slug: month-in-mathlib-${month_lc}-$year"
 echo "tags: ''"
-echo "title: This month in mathlib (${monthnames_uc[$month]} $year)"
+echo "title: This month in mathlib (${month_uc} $year)"
 echo "type: text"
 echo "---"
 
@@ -42,8 +45,7 @@ echo ""
 
 pushd $mathlib > /dev/null
 
-git log --pretty=oneline --abbrev-commit --since="1 ${monthnames_uc[$month]} $year" | tac |
+git log --date=iso-local --pretty=oneline --abbrev-commit --since "$yy-$mm-01" --until "$yy-$mm-$daysOfMonth" | tac |
 sed 's|\([^ ]*\) \(.*\) (#\([0-9]*\))|* [PR #\3](https://github.com/leanprover-community/mathlib/pull/\3) :: \2|'
 
 popd > /dev/null
-


### PR DESCRIPTION
This should pull all the commits for the specified month, using the UTC timezone.